### PR TITLE
Fix vector_cpp.cpp

### DIFF
--- a/tests/cpp/vector_cpp.cpp
+++ b/tests/cpp/vector_cpp.cpp
@@ -6,7 +6,7 @@ int fromC_ref(const std::vector<int>&);
 int sumOfElements_ref(const std::vector<int>& arr)
 {
     int r = 0;
-    for (size_t i = 0; i < arr.size(); ++i)
+    for (std::size_t i = 0; i < arr.size(); ++i)
         r += arr[i];
     return r;
 }


### PR DESCRIPTION
`size_t` needs the `std::` namespace unless `<cstddef>` in included.