### PR TITLE
std::optional

### DIFF
--- a/source/core/experimental/stdcpp/optional.d
+++ b/source/core/experimental/stdcpp/optional.d
@@ -1,0 +1,169 @@
+/**
+ * D header file for interaction with C++ std::optional.
+ *
+ * Copyright: Copyright (c) 2018 D Language Foundation
+ * License: Distributed under the
+ *      $(LINK2 http://www.boost.org/LICENSE_1_0.txt, Boost Software License 1.0).
+ *    (See accompanying file LICENSE)
+ * Authors:   Manu Evans
+ * Source:    $(DRUNTIMESRC core/stdcpp/optional.d)
+ */
+
+module core.experimental.stdcpp.optional;
+
+version (CppRuntime_DigitalMars)
+{
+    pragma(msg, "std::optional not supported by DMC");
+}
+version (CppRuntime_Clang)
+{
+    private alias AliasSeq(Args...) = Args;
+    private enum StdNamespace = AliasSeq!("std", "__1");
+}
+else
+{
+    private enum StdNamespace = "std";
+}
+
+extern(C++, (StdNamespace)):
+
+///
+struct nullopt_t {}
+
+///
+enum nullopt_t nullopt = nullopt_t();
+
+///
+struct in_place_t {}
+
+///
+enum in_place_t in_place = in_place_t();
+
+/**
+ * D language counterpart to C++ std::optional.
+ *
+ * C++ reference: $(LINK2 https://en.cppreference.com/w/cpp/utility/optional)
+ */
+extern(C++, class) struct optional(T)
+{
+	static assert(!is(Unqual!T == nullopt_t), "T in optional!T cannot be nullopt_t (N4659 23.6.2 [optional.syn]/1).");
+    static assert(!is(Unqual!T == in_place_t), "T in optional!T cannot be in_place_t (N4659 23.6.2 [optional.syn]/1).");
+    static assert(!__traits(hasMember, T, "__xpostblit"), "T in optional!T may not have a postblit `this(this)` constructor. Use copy constructor instead.");
+//	static assert(is_reference_v<_Ty> || is_object_v<_Ty>, "T in optional!T must be an object type (N4659 23.6.3 [optional.optional]/3).");
+//	static assert(is_destructible_v<_Ty> && !is_array_v<_Ty>, "T in optional!T must satisfy the requirements of Destructible (N4659 23.6.3 [optional.optional]/3).");
+
+extern(D):
+pragma(inline, true):
+
+    this(nullopt_t) pure nothrow @nogc @safe
+    {
+    }
+
+    this(Args...)(in_place_t, auto ref Args args)
+    {
+        static if (Args.length == 1 && is(Unqual!(Args[0]) == T))
+            moveEmplace(args[0], _value);
+        else
+            core_emplace(&_value, forward!args);
+        _engaged = true;
+    }
+
+    static if (hasElaborateDestructor!T)
+    {
+        ~this()
+        {
+            if (_engaged)
+                destroy!false(_value);
+        }
+    }
+
+    static if (hasElaborateCopyConstructor!T)
+    {
+        this(ref return scope inout(optional) rhs) inout
+        {
+            _engaged = rhs._engaged;
+            if (rhs._engaged)
+                core_emplace(cast(T*)&_value, rhs._value);
+        }
+    }
+
+    void opAssign(nullopt_t)
+    {
+        reset();
+    }
+
+    void opAssign()(auto ref optional!T rhs)
+    {
+        if (rhs._engaged)
+            opAssign(forward!rhs._value);
+        else
+            reset();
+    }
+
+    void opAssign()(auto ref T rhs)
+    {
+        if (_engaged)
+            _value = forward!rhs;
+        else
+        {
+            core_emplace(&_value, forward!rhs);
+            _engaged = true;
+        }
+    }
+
+    bool opCast(T : bool)() const pure nothrow @nogc @safe
+    {
+        return has_value();
+    }
+
+    void reset()
+    {
+        static if (hasElaborateDestructor!T)
+        {
+            if (_engaged)
+            {
+                destroy!false(_value);
+                _engaged = false;
+            }
+        }
+        else
+            _engaged = false;
+    }
+
+    ref T emplace(Args...)(auto ref Args args)
+    {
+        reset();
+        core_emplace(&_value, forward!args);
+        _engaged = true;
+        return _value;
+    }
+
+    bool has_value() const pure nothrow @nogc @safe
+    {
+        return _engaged;
+    }
+
+    // TODO: return by-val (move _value) if `this` is an rvalue... (auto ref return?)
+    ref T value()
+    {
+        return _value;
+    }
+
+    // TODO: return by-val (move _value) if `this` is an rvalue... (auto ref return?)
+    ref T value_or()(auto ref T or)
+    {
+        return _engaged ? _value : forward!or;
+    }
+
+private:
+    import core.internal.traits : AliasSeq, Unqual, hasElaborateDestructor, hasElaborateCopyConstructor, hasElaborateDestructor;
+    import core.lifetime : forward, moveEmplace, core_emplace = emplace;
+
+    // amazingly, MSVC, Clang and GCC all share the same struct!
+    union
+    {
+        ubyte _dummy = 0;
+        Unqual!T _value = void;
+    }
+    bool _engaged = false;
+}

--- a/stl-containers.vcxproj
+++ b/stl-containers.vcxproj
@@ -39,6 +39,7 @@
     <DCompile Include="source\core\experimental\stdcpp\array.d" />
     <DCompile Include="source\core\experimental\stdcpp\exception.d" />
     <DCompile Include="source\core\experimental\stdcpp\new_.d" />
+    <DCompile Include="source\core\experimental\stdcpp\optional.d" />
     <DCompile Include="source\core\experimental\stdcpp\string.d" />
     <DCompile Include="source\core\experimental\stdcpp\string_view.d" />
     <DCompile Include="source\core\experimental\stdcpp\typeinfo.d" />
@@ -48,6 +49,7 @@
     <DCompile Include="tests\source\allocator_test.d" />
     <DCompile Include="tests\source\array_test.d" />
     <DCompile Include="tests\source\new_test.d" />
+    <DCompile Include="tests\source\optional_test.d" />
     <DCompile Include="tests\source\string_test.d" />
     <DCompile Include="tests\source\string_view_test.d" />
     <DCompile Include="tests\source\vector_test.d" />
@@ -56,6 +58,7 @@
     <ClCompile Include="tests\cpp\allocator_cpp.cpp" />
     <ClCompile Include="tests\cpp\array_cpp.cpp" />
     <ClCompile Include="tests\cpp\new_cpp.cpp" />
+    <ClCompile Include="tests\cpp\optional_cpp.cpp" />
     <ClCompile Include="tests\cpp\string_cpp.cpp" />
     <ClCompile Include="tests\cpp\string_view_cpp.cpp" />
     <ClCompile Include="tests\cpp\vector_cpp.cpp" />

--- a/stl-containers.vcxproj.filters
+++ b/stl-containers.vcxproj.filters
@@ -72,6 +72,12 @@
     <DCompile Include="tests\source\string_view_test.d">
       <Filter>tests\source</Filter>
     </DCompile>
+    <DCompile Include="source\core\experimental\stdcpp\optional.d">
+      <Filter>source\core\experimental\stdcpp</Filter>
+    </DCompile>
+    <DCompile Include="tests\source\optional_test.d">
+      <Filter>tests\source</Filter>
+    </DCompile>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="tests\cpp\string_cpp.cpp">
@@ -90,6 +96,9 @@
       <Filter>tests\cpp</Filter>
     </ClCompile>
     <ClCompile Include="tests\cpp\string_view_cpp.cpp">
+      <Filter>tests\cpp</Filter>
+    </ClCompile>
+    <ClCompile Include="tests\cpp\optional_cpp.cpp">
       <Filter>tests\cpp</Filter>
     </ClCompile>
   </ItemGroup>

--- a/tests/cpp/optional_cpp.cpp
+++ b/tests/cpp/optional_cpp.cpp
@@ -1,16 +1,53 @@
 #include <optional>
 
+extern int opt_refCount;
+
 struct Complex
 {
+    bool valid = false;
+
     int buffer[16] = { 10 };
 
-    Complex() {}
-    ~Complex() {}
+    Complex() = delete;
+    Complex(const Complex& rh)
+    {
+        valid = rh.valid;
+        if (rh.valid)
+        {
+            ++opt_refCount;
+            for (size_t i = 0; i < 16; ++i)
+                buffer[i] = rh.buffer[i];
+        }
+    }
+    ~Complex()
+    {
+        if (valid)
+            --opt_refCount;
+    }
 };
 
-int fromC_val(std::optional<int>);
-int fromC_ref(const std::optional<int>&);
-int fromC_val(std::optional<void*>);
-int fromC_ref(const std::optional<void*>&);
-int fromC_val(std::optional<Complex>);
-int fromC_ref(const std::optional<Complex>&);
+int fromC_val(bool, std::optional<int>, const std::optional<int>&,
+    std::optional<void*>, const std::optional<void*>&,
+    std::optional<Complex>, const std::optional<Complex>&);
+
+int callC_val(bool set, std::optional<int> a1, const std::optional<int>& a2,
+    std::optional<void*> a3, const std::optional<void*>& a4,
+    std::optional<Complex> a5, const std::optional<Complex>& a6)
+{
+    if (set)
+    {
+        if (!a1 || a1.value() != 10) return 1;
+        if (!a2 || a2.value() != 10) return 1;
+        if (!a3 || a3.value() != (void*)0x1234) return 1;
+        if (!a4 || a4.value() != (void*)0x1234) return 1;
+        if (!a5 || a5.value().buffer[0] != 20 || a5.value().buffer[15] != 20) return 1;
+        if (!a6 || a6.value().buffer[0] != 20 || a6.value().buffer[15] != 20) return 1;
+    }
+    else
+    {
+        if (a1 || a2 || a3 || a4 || a5 || a6)
+            return 1;
+    }
+
+    return fromC_val(set, a1, a2, a3, a4, a5, a6);
+}

--- a/tests/cpp/optional_cpp.cpp
+++ b/tests/cpp/optional_cpp.cpp
@@ -1,0 +1,16 @@
+#include <optional>
+
+struct Complex
+{
+    int buffer[16] = { 10 };
+
+    Complex() {}
+    ~Complex() {}
+};
+
+int fromC_val(std::optional<int>);
+int fromC_ref(const std::optional<int>&);
+int fromC_val(std::optional<void*>);
+int fromC_ref(const std::optional<void*>&);
+int fromC_val(std::optional<Complex>);
+int fromC_ref(const std::optional<Complex>&);

--- a/tests/source/optional_test.d
+++ b/tests/source/optional_test.d
@@ -10,12 +10,16 @@ unittest
     assert(o1 && o1.value == 20);
     o1 = nullopt;
     assert(!o1);
+    int temp = 30;
+    assert(o1.value_or(temp) == 30);
 
     optional!(void*) o4;
     auto o5 = optional!(void*)(in_place, cast(void*)0x1234);
     assert(!o4 && o5 && o5.value == cast(void*)0x1234);
+    o4 = o5;
     o5 = null;
     assert(o5.value == null);
+    o5 = o4;
     o5.reset();
     assert(!o5);
 
@@ -33,13 +37,16 @@ unittest
         assert(o6 && o6.value.buffer[0] == 20 && o6.value.buffer[$-1] == 20);
         o7.reset();
         assert(!o7);
+
+        assert(callC_val(false, o1, o1, o5, o5, o7, o7) == 0);
+        assert(callC_val(true, o3, o3, o4, o4, o6, o6) == 0);
     }
     assert(opt_refCount == 0);
 }
 
 extern(C++):
 
-__gshared opt_refCount = 0;
+__gshared int opt_refCount = 0;
 
 struct Complex
 {
@@ -66,9 +73,25 @@ struct Complex
     }
 }
 
-//int fromC_val(optional!int);
-//int fromC_ref(ref const(optional!int));
-//int fromC_val(optional!(void*));
-//int fromC_ref(ref const(optional!(void*)));
-//int fromC_val(optional!Complex);
-//int fromC_ref(ref const(optional!Complex));
+int callC_val(bool, optional!int, ref const(optional!int), optional!(void*), ref const(optional!(void*)), optional!Complex, ref const(optional!Complex));
+
+int fromC_val(bool set, optional!int a1, ref const(optional!int) a2,
+              optional!(void*) a3, ref const(optional!(void*)) a4,
+              optional!Complex a5, ref const(optional!Complex) a6)
+{
+    if (set)
+    {
+        assert(a1 && a1.value == 10);
+        assert(a2 && a2.value == 10);
+        assert(a3 && a3.value == cast(void*)0x1234);
+        assert(a4 && a4.value == cast(void*)0x1234);
+        assert(a5 && a5.value.buffer[0] == 20 && a5.value.buffer[$-1] == 20);
+        assert(a6 && a6.value.buffer[0] == 20 && a6.value.buffer[$-1] == 20);
+    }
+    else
+    {
+        assert(!a1 && !a2 && !a3 && !a4 && !a5 && !a6);
+    }
+
+    return 0;
+}

--- a/tests/source/optional_test.d
+++ b/tests/source/optional_test.d
@@ -1,0 +1,74 @@
+import core.experimental.stdcpp.optional;
+
+unittest
+{
+    optional!int o1;
+    optional!int o2 = nullopt;
+    auto o3 = optional!int(in_place, 10);
+    assert(!o1 && o2.has_value == false && o3 && o3.value == 10);
+    o1 = 20;
+    assert(o1 && o1.value == 20);
+    o1 = nullopt;
+    assert(!o1);
+
+    optional!(void*) o4;
+    auto o5 = optional!(void*)(in_place, cast(void*)0x1234);
+    assert(!o4 && o5 && o5.value == cast(void*)0x1234);
+    o5 = null;
+    assert(o5.value == null);
+    o5.reset();
+    assert(!o5);
+
+    {
+        optional!Complex o6;
+        auto o7 = optional!Complex(in_place, Complex(20));
+        assert(!o6 && o7 && o7.value.buffer[0] == 20 && o7.value.buffer[$-1] == 20);
+        optional!Complex o8 = o6;
+        assert(!o8);
+        optional!Complex o9 = o7;
+        assert(o9 && o9.value.buffer[0] == 20 && o9.value.buffer[$-1] == 20);
+        o9 = o6;
+        assert(!o9);
+        o6 = o7;
+        assert(o6 && o6.value.buffer[0] == 20 && o6.value.buffer[$-1] == 20);
+        o7.reset();
+        assert(!o7);
+    }
+    assert(opt_refCount == 0);
+}
+
+extern(C++):
+
+__gshared opt_refCount = 0;
+
+struct Complex
+{
+    bool valid = false;
+    int[16] buffer;
+    this(int val)
+    {
+        valid = true;
+        buffer[] = val;
+        ++opt_refCount;
+    }
+    this(ref inout(Complex) rhs) inout
+    {
+        valid = rhs.valid;
+        if (rhs.valid)
+        {
+            buffer[] = rhs.buffer[]; ++opt_refCount;
+        }
+    }
+    ~this()
+    {
+        if (valid)
+            --opt_refCount;
+    }
+}
+
+//int fromC_val(optional!int);
+//int fromC_ref(ref const(optional!int));
+//int fromC_val(optional!(void*));
+//int fromC_ref(ref const(optional!(void*)));
+//int fromC_val(optional!Complex);
+//int fromC_ref(ref const(optional!Complex));


### PR DESCRIPTION
Doesn't support non-POD objects, because union is completely broken in D!